### PR TITLE
Updated Package Dependencies and README Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Poetry handles dependency- and virtual-environment-management in a way that’s 
 
 Within the urrent directory of your package, run
 
+`poetry update`
+
+Then
+
 `poetry install`
 
 ## Install ipython kernel spec

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Then
 
 ## Open the sample notebook
 
-If you are using vscode with the Python plugin, you should be able to connect to the kernel in the current vitual environment.
+If you are using vscode with the Python plugin, you should be able to connect to the kernel in the current virtual environment.
+Make sure that you select the python kernel we created, named calcium-roi-analysis
 
 Alternatively, you can fireup Jupyter Lab
 
@@ -136,3 +137,11 @@ This project includes `nbdime` a tool that facilitates seeing the difference in 
 `poetry run nbdiff-web` or `poetry run nbdiff`
 
 If working within jupyter-lab, an extension is enabled to see the differences
+
+###  Running find_roi.ipynb
+Start by making sure you have an input image, and that your yaml file has the correct file path to that input image. 
+
+After selecting the calcium-roi-analysis kernel, you can hit run all to execute all of the code blocks sequentially. After a short while, a window should pop up with an output image. Click on the image and press the f key on your keyboard to save that image to your output file. 
+
+After the image has been saved, you can run the next block of code, which probably failed as it relies on that image being created. 
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,21 @@ authors = ["Isabel Restrepo <isabelrestre@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-scikit-image = "^0.17.2"
-napari = "^0.3.1"
+scikit-image = "^0.19.1"
+napari = {extras = ["all"], version = "^0.4.16"}
+napari-console = "^0.0.4"
+napari-plugin-engine = "^0.1.9"
+napari-svg = "^0.1.5"
 PyQt5 = "^5.14.2"
 pyyaml = "^5.3.1"
+vispy = "^0.10.0"
+magicgui = "^0.3.6"
+jsonschema = "^3.2.0"
+pydantic = "^1.8.2"
+PyOpenGL = "^3.1.5"
+pooch = "^1.0.0"
+matplotlib = "^3.5.2"
+imagecodecs = "^2022.2.22"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
updated poetry package specifications and dependencies to account for issues with deprecated packages
changed README to reflect new setup instructions

The visualization team had been having an issue setting up the calcium-roi-analysis on new computers that was related to some packages being deprecated and dependencies not lining up. After manually configuring the dependencies in the toml file and calling `poetry update` during the setup process, the build succeeds and runs correctly. 

I also added a section on running find_roi.ipynb to the README